### PR TITLE
chore: client session settings

### DIFF
--- a/modules/base-realms/realm-standard/realm.tf
+++ b/modules/base-realms/realm-standard/realm.tf
@@ -14,6 +14,10 @@ module "realm" {
   realm_name   = var.standard_realm_name
   display_name = "Single Sign-On"
   login_theme  = "bcgov-idp-stopper"
+
+  client_session_idle_timeout = "30m"
+  client_session_max_lifespan = "10h"
+  sso_session_idle_timeout    = "10h"
 }
 
 module "idp_auth_flow" {

--- a/modules/realm/main.tf
+++ b/modules/realm/main.tf
@@ -17,6 +17,8 @@ resource "keycloak_realm" "this" {
   refresh_token_max_reuse                  = var.refresh_token_max_reuse
   sso_session_idle_timeout                 = var.sso_session_idle_timeout                 # SSO Session Idle
   sso_session_max_lifespan                 = var.sso_session_max_lifespan                 # SSO Session Max
+  client_session_idle_timeout              = var.client_session_idle_timeout
+  client_session_max_lifespan              = var.client_session_max_lifespan
   offline_session_idle_timeout             = var.offline_session_idle_timeout             # Offline Session Idle
   offline_session_max_lifespan_enabled     = var.offline_session_max_lifespan_enabled     # Offline Session Max Limited
   access_token_lifespan                    = var.access_token_lifespan                    # Access Token Lifespan

--- a/modules/realm/variables.tf
+++ b/modules/realm/variables.tf
@@ -39,6 +39,16 @@ variable "sso_session_max_lifespan" {
   default     = "10h"
 }
 
+variable "client_session_idle_timeout" {
+  description = "The default amount of time a client session in this realm can be idle before it expires. If left at 0, the sso_session_idle_timeout will be used."
+  default     = "0"
+}
+
+variable "client_session_max_lifespan" {
+  description = "The default maximum amount of time a client session in this realm will expire in regardless of activity. If left at 0, the sso_session_max_lifespan will be used."
+  default     = "0"
+}
+
 variable "offline_session_idle_timeout" {
   description = "The amount of time an offline session can be idle before it expires."
   default     = "720h"


### PR DESCRIPTION
set client idle and max lifespan in standard, for ssoteam-1198