### PR TITLE
chore: idp alias

### DIFF
--- a/modules/base-realms/realm-standard/idp-verifiablecredential.tf
+++ b/modules/base-realms/realm-standard/idp-verifiablecredential.tf
@@ -1,7 +1,7 @@
 module "digitalcredential_idp" {
   source                       = "../../oidc-idp"
   realm_id                     = module.realm.id
-  alias                        = "digital-credential"
+  alias                        = "digitalcredential"
   display_name                 = "Digital Credential"
   gui_order                    = "8"
   authorization_url            = var.digitalcredential_authorization_url


### PR DESCRIPTION
remove dash from idp alias