### PR TITLE
chore: error uri

### DIFF
--- a/modules/base-realms/realm-standard/realm.tf
+++ b/modules/base-realms/realm-standard/realm.tf
@@ -46,7 +46,7 @@ resource "keycloak_authentication_execution_config" "githubbcgov_exec1_config" {
   config = {
     attributeKey   = "org_verified",
     attributeValue = "true",
-    errorUrl       = "https://github.com/bcgov/sso-keycloak/wiki/Are-you-part-of-the-GitHub-BC-Gov-Org-%3F"
+    errorUrl       = "https://mvp.developer.gov.bc.ca/docs/default/component/css-docs/Are-you-part-of-the-GitHub-BC-Gov-Org"
   }
 }
 

--- a/modules/client-stopper-auth-flow/main.tf
+++ b/modules/client-stopper-auth-flow/main.tf
@@ -13,16 +13,24 @@ resource "keycloak_authentication_execution" "exec1" {
 resource "keycloak_authentication_execution" "exec2" {
   realm_id          = var.realm_id
   parent_flow_alias = keycloak_authentication_flow.this.alias
-  authenticator     = "identity-provider-stopper"
+  authenticator     = "cookie-stopper"
   requirement       = "ALTERNATIVE"
   depends_on        = [keycloak_authentication_execution.exec1]
 }
 
-
 resource "keycloak_authentication_execution" "exec3" {
+  realm_id          = var.realm_id
+  parent_flow_alias = keycloak_authentication_flow.this.alias
+  authenticator     = "identity-provider-stopper"
+  requirement       = "ALTERNATIVE"
+  depends_on        = [keycloak_authentication_execution.exec2]
+}
+
+
+resource "keycloak_authentication_execution" "exec4" {
   realm_id          = var.realm_id
   parent_flow_alias = keycloak_authentication_flow.this.alias
   authenticator     = "identity-provider-stop-form"
   requirement       = "ALTERNATIVE"
-  depends_on        = [keycloak_authentication_execution.exec2]
+  depends_on        = [keycloak_authentication_execution.exec3]
 }


### PR DESCRIPTION
Update bcgov error uri for production. Github UI is showing an addition to the client-stopper module, this is already in. I think because of the hotfix change in prod it never brought in that original commit so github is showing it again