### PR TITLE
chore: microsoft mappers

### DIFF
--- a/modules/base-realms/realm-microsoft/client-standard.tf
+++ b/modules/base-realms/realm-microsoft/client-standard.tf
@@ -3,6 +3,6 @@ module "standard_client" {
   realm_id            = module.realm.id
   client_id           = "${var.standard_realm_name}-realm"
   valid_redirect_uris = ["${var.keycloak_url}/auth/realms/${var.standard_realm_name}/broker/${var.realm_name}/endpoint", "${var.keycloak_url}/auth/realms/${var.standard_realm_name}/broker/${var.realm_name}/endpoint/logout_response"]
-  public_attrs        = ["email"]
+  public_attrs        = []
   sub_to_username     = var.sub_to_username
 }

--- a/modules/base-realms/realm-microsoft/idp-microsoft.tf
+++ b/modules/base-realms/realm-microsoft/idp-microsoft.tf
@@ -15,3 +15,55 @@ module "microsoft_idp" {
   disable_user_info     = true
   backchannel_supported = false
 }
+
+resource "keycloak_custom_identity_provider_mapper" "microsoft_first_name" {
+  realm                    = module.realm.id
+  name                     = "first_name"
+  identity_provider_alias  = module.microsoft_idp.alias
+  identity_provider_mapper = "hardcoded-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode = "FORCE"
+    "attribute" : "firstName"
+    "attribute.value" : ""
+  }
+}
+
+resource "keycloak_custom_identity_provider_mapper" "microsoft_last_name" {
+  realm                    = module.realm.id
+  name                     = "last_name"
+  identity_provider_alias  = module.microsoft_idp.alias
+  identity_provider_mapper = "hardcoded-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode = "FORCE"
+    "attribute" : "lastName"
+    "attribute.value" : ""
+  }
+}
+
+resource "keycloak_custom_identity_provider_mapper" "microsoft_email" {
+  realm                    = module.realm.id
+  name                     = "email"
+  identity_provider_alias  = module.microsoft_idp.alias
+  identity_provider_mapper = "hardcoded-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode = "FORCE"
+    "attribute" : "email"
+    "attribute.value" : ""
+  }
+}
+
+resource "keycloak_custom_identity_provider_mapper" "sub_username" {
+  realm                    = module.realm.id
+  name                     = "username"
+  identity_provider_alias  = module.microsoft_idp.alias
+  identity_provider_mapper = "oidc-user-attribute-idp-mapper"
+
+  extra_config = {
+    syncMode = "FORCE"
+    "user.attribute": "username"
+    claim = "sub"
+  }
+}


### PR DESCRIPTION
Microsoft idp is saving user info even with just openid scope and user info disabled. Adding mappers to ignore any PI and map the microsoft sub through to the standard realm